### PR TITLE
feat: wipe and validate modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Will write the configuration of all sources, destinations, and connections to `m
 Note in this case, no `--secrets` file is specified, since it has no meaning in this workflow. Secrets can't be extracted from the Airbyte API.
 
 ## Wipe a deployment
-The `wipe` mode deletes all sources, destinations, connections or any combination in an existing Airbyte deployment.
+The `wipe` mode deletes sources, destinations, connections or any combination in an existing Airbyte deployment.
 
 `python tentacle.py wipe http://123.456.789.0:8081 --all`
 
@@ -80,6 +80,15 @@ As with `sync`ing a .yaml file to a deployment, these optional arguments can be 
 - `--all` (same as `--sources --destinations --connections`)
 
 ## Validate a deployment
+The `validate` mode validates sources, destinations, connections or any combination in an existing Airbyte deployment.
+
+`python tentacle.py validate http://123.456.789.0:8081 --all`
+
+As with `wipe` mode, these optional arguments can be used in combination to define what to apply the `validate` operation to:
+- `--sources`
+- `--destinations`
+- `--connections`
+- `--all` (same as `--sources --destinations --connections`)
 
 # Design
 

--- a/README.md
+++ b/README.md
@@ -68,17 +68,26 @@ Will write the configuration of all sources, destinations, and connections to `m
 
 Note in this case, no `--secrets` file is specified, since it has no meaning in this workflow. Secrets can't be extracted from the Airbyte API.
 
-### Wipe a deployment
+## Wipe a deployment
+The `wipe` mode deletes all sources, destinations, connections or any combination in an existing Airbyte deployment.
 
-### Validate a deployment
+`python tentacle.py wipe http://123.456.789.0:8081 --all`
 
-## Design
+As with `sync`ing a .yaml file to a deployment, these optional arguments can be used in combination to define what to apply the wipe operation to:
+- `--sources`
+- `--destinations`
+- `--connections`
+- `--all` (same as `--sources --destinations --connections`)
 
-## Contributing
+## Validate a deployment
 
-## Acknowledgements
+# Design
 
-## License
+# Contributing
+
+# Acknowledgements
+
+# License
 Copyright 2021 Robert Stolz
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:

--- a/airbyte_client.py
+++ b/airbyte_client.py
@@ -74,7 +74,6 @@ class AirbyteClient:
         r = requests.post(route, json=payload)
         return AirbyteResponse(r)
 
-
     def delete_source(self, source_dto):
         """Route: POST /v1/sources/delete"""
         route = self.airbyte_url + 'api/v1/sources/delete'

--- a/airbyte_config_model.py
+++ b/airbyte_config_model.py
@@ -19,12 +19,6 @@ class AirbyteConfigModel:
     def apply_to_deployment(self, client):
         pass
 
-    def full_wipe(self, client):
-        self.wipe_sources(client)
-        self.wipe_destinations(client)
-        # self.wipe_connections(client)
-        pass
-
     def wipe_sources(self, client):
         """Removes all sources in self.sources from the deployment and the model"""
         # TODO: delete_sources would ideally return an AirbyteResponse and not a bool.
@@ -50,6 +44,7 @@ class AirbyteConfigModel:
 
     def validate(self, client):
         """this function validates the model and all included connectors"""
+        print("Validating connectors...")
         for source in self.sources.values():
             response = client.check_source_connection(source).payload
             print("Source is valid: " + source.source_id + ' ' + repr(response['jobInfo']['succeeded']))

--- a/airbyte_config_model.py
+++ b/airbyte_config_model.py
@@ -53,3 +53,18 @@ class AirbyteConfigModel:
             print("Destination is valid: " + destination.destination_id + ' ' + repr(response['jobInfo']['succeeded']))
         for connection in self.connections.values():
             pass  # TODO: implement connection validation
+
+    def validate_sources(self, client):
+        for source in self.sources.values():
+            response = client.check_source_connection(source).payload
+            print("Source is valid: " + source.source_id + ' ' + repr(response['jobInfo']['succeeded']))
+
+    def validate_destinations(self, client):
+        for destination in self.destinations.values():
+            response = client.check_destination_connection(destination).payload
+            print("Destination is valid: " + destination.destination_id + ' ' + repr(response['jobInfo']['succeeded']))
+            
+    def validate_connections(self, client):
+        for connection in self.connections.values():
+            response = client.check_connection_connection(connection).payload
+            print("connection is valid: " + connection.connection_id + ' ' + repr(response['jobInfo']['succeeded']))

--- a/controller.py
+++ b/controller.py
@@ -74,6 +74,7 @@ class Controller:
         return airbyte_model
 
     def get_workspace(self, args, client):
+        """Retrieves workspace specified by the --workspace argument, or the default workspace otherwise"""
         if args.workspace_slug:
             workspace = client.get_workspace_by_slug(args.workspace_slug).payload
         else:
@@ -81,6 +82,7 @@ class Controller:
         return workspace
 
     def build_dtos_from_yaml_config(self, yaml_config, secrets):
+        """Creates a dict of new DTOs by parsing the user specified .yml config file"""
         new_dtos = {}
         if 'global' in yaml_config.keys():
             for item in yaml_config['global']:
@@ -125,34 +127,42 @@ class Controller:
                 pass  # TODO: modify existing destination
 
     def wipe_sources(self, airbyte_model, client):
+        """Wrapper for AirbyteConfigModel.wipe_sources"""
         print("Wiping sources on " + client.airbyte_url)
         airbyte_model.wipe_sources(client)
 
     def wipe_destinations(self, airbyte_model, client):
+        """Wrapper for AirbyteConfigModel.wipe_destinations"""
         print("Wiping destinations on " + client.airbyte_url)
         airbyte_model.wipe_destinations(client)
 
     def wipe_connections(self, airbyte_model, client):
+        """Wrapper for AirbyteConfigModel.wipe_connections"""
         pass  # TODO: implement controller.wipe_connections
 
     def wipe_all(self, airbyte_model, client):
+        """Wipes all sources, destinations, and connections in the specified airbyte deployment"""
         print("Wiping deployment: " + client.airbyte_url)
         self.wipe_sources(airbyte_model, client)
         self.wipe_destinations(airbyte_model, client)
         # self.wipe_connections(client)
 
     def validate_sources(self, airbyte_model, client):
+        """Wrapper for AirbyteConfigModel.validate_sources"""
         print("Validating sources...")
         airbyte_model.validate_sources(client)
 
     def validate_destinations(self, airbyte_model, client):
+        """Wrapper for AirbyteConfigModel.validate_destinations"""
         print("Validating destinations...")
         airbyte_model.validate_destinations(client)
 
     def validate_connections(self, airbyte_mopdel, client):
+        """Wrapper for AirbyteConfigModel.validate_connections"""
         pass  # TODO: implement Controller.validate_connections
 
     def validate_all(self, airbyte_model, client):
+        """Validates all sources, destinations, and connections in the specified AirbyteConfigModel"""
         self.validate_sources(airbyte_model, client)
         self.validate_destinations(airbyte_model, client)
         #self.validate_connections(airbyte_model, client)

--- a/controller.py
+++ b/controller.py
@@ -52,10 +52,11 @@ class Controller:
 
     def get_airbyte_configuration(self, client, workspace):
         """Retrieves the configuration from an airbyte deployment and returns an AirbyteConfigModel representing it"""
+        print("Reading configuration from source yaml")
         configured_sources = client.get_configured_sources(workspace).payload['sources']
         configured_destinations = client.get_configured_destinations(workspace).payload['destinations']
         configured_connections = client.get_configured_connections(workspace).payload['connections']
-        print("main: retrieved configuration from: " + client.airbyte_url)
+        print("Retrieved configuration from: " + client.airbyte_url)
         airbyte_model = AirbyteConfigModel()
         for source in configured_sources:
             source_dto = self.dto_factory.build_source_dto(source)

--- a/controller.py
+++ b/controller.py
@@ -5,7 +5,7 @@ import utils
 import yaml
 
 class Controller:
-    """The controller controls program flow and communicates with the outside world"""
+    """Communicates with the user. Provides methods to execute the subtasks for each workflow."""
     def __init__(self):
         self.dto_factory = None
 
@@ -13,8 +13,11 @@ class Controller:
         self.dto_factory = AirbyteDtoFactory(source_definitions,destination_definitions)
 
     def instantiate_client(self, args):
+        # if origin is a deployment and target is not specified
+        if not utils.is_yaml(args.origin) and args.target is None:
+            client = AirbyteClient(args.origin)
         # if in sync mode and source is a yaml file
-        if utils.is_yaml(args.origin):
+        elif utils.is_yaml(args.origin):
             if utils.is_yaml(args.target):
                 print("Fatal error: --target must be followed by a valid "
                       "Airbyte deployment url when the origin is a .yaml file")
@@ -31,7 +34,7 @@ class Controller:
             exit(2)
         return client
 
-    def read_yaml_config(self, args):  # TODO: Move into controller
+    def read_yaml_config(self, args):
         """get config from config.yml"""
         if utils.is_yaml(args.origin):
             yaml_config = yaml.safe_load(open(args.origin, 'r'))
@@ -116,8 +119,22 @@ class Controller:
             else:
                 pass  # TODO: modify existing destination
 
-    def wipe(self, airbyte_model, client):
-        airbyte_model.full_wipe(client)
+    def wipe_sources(self, airbyte_model, client):
+        print("Wiping sources on " + client.airbyte_url)
+        airbyte_model.wipe_sources(client)
+
+    def wipe_destinations(self, airbyte_model, client):
+        print("Wiping destinations on " + client.airbyte_url)
+        airbyte_model.wipe_destinations(client)
+
+    def wipe_all(self, airbyte_model, client):
+        print("Wiping deployment: " + client.airbyte_url)
+        airbyte_model.wipe_sources(client)
+        airbyte_model.wipe_destinations(client)
+        # airbyte_model.wipe_connections(client)
+
+    def wipe_connections(self):
+        pass  # TODO: implement controller.wipe_connections
 
     def validate(self):
         pass

--- a/controller.py
+++ b/controller.py
@@ -36,11 +36,15 @@ class Controller:
 
     def read_yaml_config(self, args):
         """get config from config.yml"""
+        secrets = None
         if utils.is_yaml(args.origin):
             yaml_config = yaml.safe_load(open(args.origin, 'r'))
         else:
             yaml_config = yaml.safe_load(open(args.target, 'r'))
-        secrets = yaml.safe_load(open(args.secrets, 'r'))
+        if args.secrets:
+            secrets = yaml.safe_load(open(args.secrets, 'r'))  # TODO: if no --secrets specified, skip
+        else:
+            print("Warning: Reading yaml config but --secrets not specified.")
         return yaml_config, secrets
 
     def get_definitions(self, client):
@@ -133,10 +137,22 @@ class Controller:
 
     def wipe_all(self, airbyte_model, client):
         print("Wiping deployment: " + client.airbyte_url)
-        airbyte_model.wipe_sources(client)
-        airbyte_model.wipe_destinations(client)
-        # airbyte_model.wipe_connections(client)
+        self.wipe_sources(airbyte_model, client)
+        self.wipe_destinations(airbyte_model, client)
+        # self.wipe_connections(client)
 
-    def validate(self, airbyte_model: AirbyteConfigModel, client):
-        print("Validating connectors...")
-        airbyte_model.validate(client)
+    def validate_sources(self, airbyte_model, client):
+        print("Validating sources...")
+        airbyte_model.validate_sources(client)
+
+    def validate_destinations(self, airbyte_model, client):
+        print("Validating destinations...")
+        airbyte_model.validate_destinations(client)
+
+    def validate_connections(self, airbyte_mopdel, client):
+        pass  # TODO: implement Controller.validate_connections
+
+    def validate_all(self, airbyte_model, client):
+        self.validate_sources(airbyte_model, client)
+        self.validate_destinations(airbyte_model, client)
+        #self.validate_connections(airbyte_model, client)

--- a/controller.py
+++ b/controller.py
@@ -128,14 +128,15 @@ class Controller:
         print("Wiping destinations on " + client.airbyte_url)
         airbyte_model.wipe_destinations(client)
 
+    def wipe_connections(self, airbyte_model, client):
+        pass  # TODO: implement controller.wipe_connections
+
     def wipe_all(self, airbyte_model, client):
         print("Wiping deployment: " + client.airbyte_url)
         airbyte_model.wipe_sources(client)
         airbyte_model.wipe_destinations(client)
         # airbyte_model.wipe_connections(client)
 
-    def wipe_connections(self):
-        pass  # TODO: implement controller.wipe_connections
-
-    def validate(self):
-        pass
+    def validate(self, airbyte_model: AirbyteConfigModel, client):
+        print("Validating connectors...")
+        airbyte_model.validate(client)

--- a/tentacle.py
+++ b/tentacle.py
@@ -14,8 +14,9 @@ TODO LIST:
     - (done) Clarify all arg processor functions related to this workflow
     - implement the --dump option
     - (stretch): modification of connections
-- Deployment to yaml workflow
+- (done) Deployment to yaml workflow
 - (done) Wipe target workflow
+- (done) Validate workflow
 - (in progress) README.md
 - (done) License
 - Decorators

--- a/tentacle.py
+++ b/tentacle.py
@@ -64,12 +64,14 @@ def main(args):
             print("Applying changes to deployment: " + client.airbyte_url)
             if args.sources or args.all:
                 controller.sync_sources(airbyte_model, client, workspace, new_dtos)
+                if args.validate:
+                    controller.validate_sources(airbyte_model, client)
             if args.destinations or args.all:
                 controller.sync_destinations(airbyte_model, client, workspace, new_dtos)
+                if args.validate:
+                    controller.validate_destinations(airbyte_model, client)
             if args.connections or args.all:
                 pass  # TODO: implement controller.sync_connection
-            if args.validate:
-                airbyte_model.validate(client)
 
     # wipe workflow
     elif args.mode == 'wipe':
@@ -82,7 +84,12 @@ def main(args):
 
     # validate workflow
     elif args.mode == 'validate':
-        airbyte_model.validate(client)
+        if args.sources or args.all:
+            controller.validate_sources(airbyte_model, client)
+        if args.destinations or args.all:
+            controller.validate_destinations(airbyte_model, client)
+        if args.connections or args.all:
+            pass  # TODO: implement controller.wipe_connections
     else:
         print("main: unrecognized mode " + args.mode)
 

--- a/tentacle.py
+++ b/tentacle.py
@@ -20,6 +20,7 @@ TODO LIST:
 - (in progress) README.md
 - (done) License
 - Decorators
+- Type hinting
 - Tests!
 - Post 0.1.0
     - CI
@@ -81,7 +82,6 @@ def main(args):
 
     # validate workflow
     elif args.mode == 'validate':
-        print("Validating connectors...")
         airbyte_model.validate(client)
     else:
         print("main: unrecognized mode " + args.mode)

--- a/tentacle.py
+++ b/tentacle.py
@@ -48,7 +48,6 @@ def main(args):
     definitions = controller.get_definitions(client)
     controller.instantiate_dto_factory(definitions['source_definitions'], definitions['destination_definitions'])
     workspace = controller.get_workspace(args, client)
-    print("main: read configuration from source yaml")
     airbyte_model = controller.get_airbyte_configuration(client, workspace)
 
     # sync workflow

--- a/tentacle.py
+++ b/tentacle.py
@@ -37,7 +37,7 @@ from airbyte_client import AirbyteClient
 from controller import Controller
 
 
-VALID_MODES = ['wipe', 'update', 'validate', 'sync']
+VALID_MODES = ['wipe', 'validate', 'sync']
 
 def is_yaml(name):
     if name.strip().split('.')[-1] == 'yml' or name.strip().split('.')[-1] == 'yaml':
@@ -123,7 +123,7 @@ if __name__ == "__main__":
 
     # Required positional argument
     #parser.add_argument("arg", help="Required positional argument")
-    parser.add_argument("mode", help="Operating mode. Choices are sync, validate, wipe, update")
+    parser.add_argument("mode", help="Operating mode. Choices are sync, validate, wipe")
     parser.add_argument("origin", help="location of the source Airbyte deployment or yaml file")
 
     # Optional argument flag which defaults to False

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,5 @@
+def is_yaml(name):
+    if name.strip().split('.')[-1] == 'yml' or name.strip().split('.')[-1] == 'yaml':
+        return True
+    else:
+        return False


### PR DESCRIPTION
The idea here is to implement wipe and validate, both of which are options in `sync` mode, as their own top-level master modes. There are reasons why I think this makes sense:
- It's conceptually awkward to use sync mode when not syncing configuration from a source to an origin.
- Breaks some of the optional functionality of sync mode out and allows the application to be used more modularly. 
- Wiping is dangerous. Maybe we don't want to provide the option to wipe as an option when using sync mode. Force the user to run the application in wipe mode.
- Fits into a pattern that may make more sense as more top-level modes are added, some of which may not use a source + an origin, or might use a source, an origin, and something else.

This PR does these things:
- Implements wipe and validate as their own top-level master modes with `--all`, `--sources`, `--destinations`, and `connections` as selectable options.
- Refactoring in the main method to bring the controller object closer to in-line with its intended functions: handle communication with the user and provide methods that define the subtasks in each workflow.
- Minor tweaks, cleanup and refactoring
- Updates relevant documentation and TODO LIST