### PR TITLE
feat: modify existing sources and destinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ There are a number of additional optional parameters that modify how a sync oper
 - `--dump` dumps the full configuration of the destination deployment to a configuration
 **before** applying the sync operation.
 
+### Modifying existing sources and destinations
+
+If the yaml file specifies connectors with `sourceId` or `destinationId` matching connectors in the target Airbyte deployment, then tentacle will attempt to modify the existing connector instead of creating a new one. Any changes to the `connectionConfiguration` will be applied to the existing connector.
+
 ### Sync deployment to yaml
 
 An existing Airbyte deployment can be written to a .yaml by following the `--target` argument with a filename having the .yaml or .yml extension. For example:

--- a/airbyte_client.py
+++ b/airbyte_client.py
@@ -88,9 +88,15 @@ class AirbyteClient:
         r = requests.post(route, json={'workspaceId': workspace['workspaceId']})
         return AirbyteResponse(r)
 
-    def update_source(self):
+    def update_source(self, source_dto):
         """Route: POST /v1/sources/update"""
-        pass
+        route = self.airbyte_url + 'api/v1/sources/update'
+        payload = {'sourceId': source_dto.source_id,
+                   'connectionConfiguration': source_dto.connection_configuration,
+                   'name': source_dto.name}
+
+        r = requests.post(route, json=payload)
+        return AirbyteResponse(r)
 
     def check_destination_connection(self, destination_dto):
         """Route: POST /v1/destinations/check_connection"""

--- a/airbyte_client.py
+++ b/airbyte_client.py
@@ -94,7 +94,6 @@ class AirbyteClient:
         payload = {'sourceId': source_dto.source_id,
                    'connectionConfiguration': source_dto.connection_configuration,
                    'name': source_dto.name}
-
         r = requests.post(route, json=payload)
         return AirbyteResponse(r)
 

--- a/airbyte_client.py
+++ b/airbyte_client.py
@@ -135,9 +135,14 @@ class AirbyteClient:
         r = requests.post(route, json={'workspaceId': workspace['workspaceId']})
         return AirbyteResponse(r)
 
-    def update_destination(self):
+    def update_destination(self, destination_dto):
         """Route: POST /v1/destinations/update"""
-        pass
+        route = self.airbyte_url + 'api/v1/destinations/update'
+        payload = {'destinationId': destination_dto.destination_id,
+                   'connectionConfiguration': destination_dto.connection_configuration,
+                   'name': destination_dto.name}
+        r = requests.post(route, json=payload)
+        return AirbyteResponse(r)
 
     def create_connection(self):
         """Route: POST /v1/connections/create"""

--- a/airbyte_dto_factory.py
+++ b/airbyte_dto_factory.py
@@ -32,7 +32,7 @@ class AirbyteDtoFactory:
         if 'sourceId' in source:
             r.source_id = source['sourceId']
         if 'workspaceId' in source:
-            r.workspace_id = source['sourceId']
+            r.workspace_id = source['workspaceId']
         if 'tag' in source:
             r.tag = source['tag']
         # TODO: check for validity?
@@ -52,7 +52,7 @@ class AirbyteDtoFactory:
         if 'destinationId' in destination:
             r.destination_id = destination['destinationId']
         if 'workspaceId' in destination:
-            r.workspace_id = destination['destinationId']
+            r.workspace_id = destination['workspaceId']
         if 'tag' in destination:
             r.tag = destination['tag']
         # TODO: check for validity?

--- a/airbyte_dto_factory.py
+++ b/airbyte_dto_factory.py
@@ -6,17 +6,18 @@ class AirbyteDtoFactory:
 
     def populate_secrets(self, secrets, new_dtos):
         # TODO: Find a better way to deal with unpredictably named secrets
-        for source in new_dtos['sources']:
-            if source.source_name in secrets['sources']:
-                if 'access_token' in source.connection_configuration:
-                    source.connection_configuration['access_token'] = secrets['sources'][source.source_name]['access_token']
-                elif 'token' in source.connection_configuration:
-                    source.connection_configuration['token'] = secrets['sources'][source.source_name]['token']
-        for destination in new_dtos['destinations']:
-            if destination.destination_name in secrets['destinations']:
-                if 'password' in destination.connection_configuration:
-                    destination.connection_configuration['password'] = secrets['destinations'][destination.destination_name]['password']
-        pass
+        if 'sources' in new_dtos:
+            for source in new_dtos['sources']:
+                if source.source_name in secrets['sources']:
+                    if 'access_token' in source.connection_configuration:
+                        source.connection_configuration['access_token'] = secrets['sources'][source.source_name]['access_token']
+                    elif 'token' in source.connection_configuration:
+                        source.connection_configuration['token'] = secrets['sources'][source.source_name]['token']
+        if 'destinations' in new_dtos:
+            for destination in new_dtos['destinations']:
+                if destination.destination_name in secrets['destinations']:
+                    if 'password' in destination.connection_configuration:
+                        destination.connection_configuration['password'] = secrets['destinations'][destination.destination_name]['password']
 
     def build_source_dto(self, source):
         r = SourceDto()

--- a/controller.py
+++ b/controller.py
@@ -114,7 +114,7 @@ class Controller:
                 print("Created source: " + source_dto.source_id)
                 airbyte_model.sources[source_dto.source_id] = source_dto
             else:
-                pass  # TODO: modify existing source
+                client.update_source(new_source)
 
     def sync_destinations(self, airbyte_model, client, workspace, new_dtos):
         for new_destination in new_dtos['destinations']:

--- a/controller.py
+++ b/controller.py
@@ -129,7 +129,13 @@ class Controller:
                 print("Created destination: " + destination_dto.destination_id)
                 airbyte_model.destinations[destination_dto.destination_id] = destination_dto
             else:
-                pass  # TODO: modify existing destination
+                response = client.update_destination(new_destination)
+                if response.ok:
+                    destination_dto = self.dto_factory.build_destination_dto(response.payload)
+                    airbyte_model.destinations[destination_dto.destination_id] = destination_dto
+                    print("Modified destination: " + destination_dto.destination_id)
+                else:
+                    print("Error: unable to modify destination: " + new_destination.destination_id)
 
     def wipe_sources(self, airbyte_model, client):
         """Wrapper for AirbyteConfigModel.wipe_sources"""

--- a/tentacle.py
+++ b/tentacle.py
@@ -10,7 +10,7 @@ TODO LIST:
 - Finalize the yaml to deployment workflow
     - (done) Add print statements to create_source and create_destination
     - (done) Add ability for user to override workspace slug
-    - Address modification of existing sources and destinations
+    - (in progress) Address modification of existing sources and destinations
     - (done) Clarify all arg processor functions related to this workflow
     - implement the --dump option
     - (stretch): modification of connections


### PR DESCRIPTION
It would be nice if the user could not just specify new connectors in the yaml file to by synced to a deployment, but also modify existing connectors. This is the outline of that design.

### Design
1. During a sync operation, connectors in a provided config.yml will be treated as possibly existing on a case by case basis iff a valid `source_id` or `destination_id` is provided. 
2. If the provided connector uuid is invalid, print a warning to make the user aware and ignore the connector. This will prevent creating duplicate connectors or inadvertently modifying the wrong connector. The alternative would have been to use the connector's name, but this is not necessarily unique and therefore unsafe. 
3. The `Controller.sync_{connector-type}` function should own both creating new connectors and modifying existing connectors via a provided AirbyteConfigModel and AirbyteClient. It should also own communicating the results of these operations to the user.

### TODO LIST
1. Implement update source and update destination routes in the AirbyteClient class.
2. Have the `Controller.read_config_from_yaml` function...?
3. Have the `Controller.sync_sources` and `Controller.sync_destinations` functions check if a provided id matches an id in the deployment.
4. If so, hit the appropriate update route
5. If not, print a warning and ignore the dto.
6. Documentation in README.md