### PR TITLE
feat: Implement the --backup option in sync mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Almost all sources and destinations will have associated secrets. Tentacle ignor
 There are a number of additional optional parameters that modify how a sync operation is carried out when syncing yaml to deployment.
 - `--wipe` removes all sources, destinations, and connectors **before** applying config.yml
 - `--validate` validates the sources, destinations, and connections on the destination Airbyte deployment **after** applying changes.
-- `--dump` dumps the full configuration of the destination deployment to a configuration
+- `--backup` followed by a filename. Dumps the full configuration of the destination deployment to a configuration
 **before** applying the sync operation.
 
 ### Modifying existing sources and destinations

--- a/tentacle.py
+++ b/tentacle.py
@@ -10,9 +10,9 @@ TODO LIST:
 - Finalize the yaml to deployment workflow
     - (done) Add print statements to create_source and create_destination
     - (done) Add ability for user to override workspace slug
-    - (in progress) Address modification of existing sources and destinations
+    - (done) Address modification of existing sources and destinations
     - (done) Clarify all arg processor functions related to this workflow
-    - implement the --dump option
+    - (in progress) implement the --dump option
     - (stretch): modification of connections
 - (done) Deployment to yaml workflow
 - (done) Wipe target workflow

--- a/tentacle.py
+++ b/tentacle.py
@@ -12,7 +12,7 @@ TODO LIST:
     - (done) Add ability for user to override workspace slug
     - (done) Address modification of existing sources and destinations
     - (done) Clarify all arg processor functions related to this workflow
-    - (in progress) implement the --dump option
+    - (in progress) implement the --backup option
     - (stretch): modification of connections
 - (done) Deployment to yaml workflow
 - (done) Wipe target workflow
@@ -59,6 +59,8 @@ def main(args):
         else:
             yaml_config, secrets = controller.read_yaml_config(args)
             new_dtos = controller.build_dtos_from_yaml_config(yaml_config, secrets)
+            if args.backup_file:
+                airbyte_model.write_yaml(args.backup_file)
             if args.wipe:
                 controller.wipe_all(airbyte_model, client)
             print("Applying changes to deployment: " + client.airbyte_url)
@@ -120,8 +122,8 @@ if __name__ == "__main__":
     # Optional argument which requires a parameter (eg. -d test)
     parser.add_argument("--target", action="store", dest="target",
                         help="specifies the airbyte deployment or yaml file to modify")
-    parser.add_argument("--dump", action="store", dest="dump_file",
-                        help="specifies a .yaml file to dump the configuration of the destination before syncing")
+    parser.add_argument("--backup", action="store", dest="backup_file",
+                        help="specifies a .yaml file to backup the configuration of the target before syncing")
     parser.add_argument("--secrets", action="store", dest="secrets",
                         help="specifies a .yaml file containing the secrets for each source and destination type")
     parser.add_argument("--workspace", action="store", dest="workspace_slug",


### PR DESCRIPTION
The idea here is to enable the user to save the configuration of an airbyte deployment to file before applying any changes, in case something goes wrong. 

The user should be able to use the `--backup` option followed by a filename to dump the configuration of the `--target` Airbyte deployment to file before attempting any modifications.